### PR TITLE
Change wording of Arch team travelling from abroad

### DIFF
--- a/content/pages/sponsoring.md
+++ b/content/pages/sponsoring.md
@@ -17,8 +17,8 @@ of volunteers, that work on several facets of the distribution. To enable us to
 bring as many of our team to Berlin this year, we need your support!
 
 We plan on providing travel grants for those of us in need of it (e.g.
-travelling from Asia or the Americas). If you or your company are interested in
-acting as a monetary sponsor for our event, please contact us via
+travelling from outside of Europe or students). If you or your company are
+interested in acting as a monetary sponsor for our event, please contact us via
 [archconf@archlinux.org](mailto:archconf@archlinux.org).
 
 As compensation for your monetary sponsoring we can offer you a prominent spot


### PR DESCRIPTION
To circumvent excluding attendees travelling from for example Africa or
other continents from a travel grant adjust the text to from outside of
Europe. Also mention students who have a low budget for attending
conferences.